### PR TITLE
Add Errata for Section 12.6 Code Example

### DIFF
--- a/errata.md
+++ b/errata.md
@@ -1,13 +1,19 @@
 # Errata for *Learn to Program with Assembly*
 
-On **page xx** [Summary of error]:
- 
-Details of error here. Highlight key pieces in **bold**.
+In **Section 12.6** [exponentscanf.s scanformat variable is malformed]:
 
-***
+Instead of the following:
+```
+scanformat:
+  .ascii "%d %d\0"
+```
 
-On **page xx** [Summary of error]:
- 
-Details of error here. Highlight key pieces in **bold**.
+The code should be:
+```
+scanformat:
+  .ascii "%**L**d %**L**d\0"
+```
+
+This is so that the fscanf function will replace the entire quad-word memory locations for the stack variables instead of the lesser-significant portion of that memory. Previously, if there was garbage data in the higher-significant double-word, it could affect the exponent function countdown.
 
 ***

--- a/errata.md
+++ b/errata.md
@@ -11,7 +11,7 @@ scanformat:
 The code should be:
 ```
 scanformat:
-  .ascii "%**L**d %**L**d\0"
+  .ascii "%Ld %Ld\0"
 ```
 
 This is so that the fscanf function will replace the entire quad-word memory locations for the stack variables instead of the lesser-significant portion of that memory. Previously, if there was garbage data in the higher-significant double-word, it could affect the exponent function countdown.


### PR DESCRIPTION
This PR contains an addition to the errata markdown to include a correction to the code example in exponentscanf.s in section 12.6.

It was discovered that the fscanf function requires modifiers in the scanformat variable so that it stores the matched input values with a matching size to the memory locations. 

As an example, if you were to run the code and enter "2 3" for 2^3 without the modifiers, and the stack location for the exponent location previously contained 0x0000000700000000, fscanf would populate this stack memory location with 0x0000000700000003. When getting to the exponent function, it would loop 30064771075 times versus 3 times.